### PR TITLE
feat: Q CLI検出とプロセス起動機能の実装 (タスク03)

### DIFF
--- a/src/examples/test-spawn.ts
+++ b/src/examples/test-spawn.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env tsx
+
+import { detectQCLI, spawnQ } from '../lib/index.js'
+
+async function main() {
+  try {
+    // Q CLIの検出
+    console.log('Q CLIを検出中...')
+    const qPath = await detectQCLI()
+    console.log(`✓ Q CLIが見つかりました: ${qPath}`)
+    
+    // ヘルプコマンドを実行
+    console.log('\n--helpコマンドを実行中...')
+    const result = await spawnQ(['--help'], {
+      onData: (type, data) => {
+        if (type === 'stdout') {
+          process.stdout.write(data)
+        } else {
+          process.stderr.write(data)
+        }
+      }
+    })
+    
+    console.log(`\n✓ コマンドが完了しました (終了コード: ${result.exitCode})`)
+  } catch (error) {
+    console.error('エラーが発生しました:', error)
+    process.exit(1)
+  }
+}
+
+main()

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,3 @@
+export { detectQCLI } from './q-cli-detector.js'
+export { spawnQ } from './spawn-q.js'
+export type { SpawnQOptions, SpawnQResult } from './spawn-q.js'

--- a/src/lib/q-cli-detector.test.ts
+++ b/src/lib/q-cli-detector.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { detectQCLI } from './q-cli-detector.js'
+import child_process from 'node:child_process'
+import { promisify } from 'node:util'
+
+vi.mock('node:child_process')
+vi.mock('node:util', () => ({
+  promisify: vi.fn((fn) => fn)
+}))
+
+describe('Q CLI検出', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    delete process.env.Q_BIN
+  })
+
+  afterEach(() => {
+    delete process.env.Q_BIN
+  })
+
+  it('Q_BIN環境変数が設定されている場合、その値を返す', async () => {
+    // Arrange
+    process.env.Q_BIN = '/custom/path/to/q'
+    const mockExec = vi.fn().mockResolvedValue({ stdout: '/custom/path/to/q', stderr: '' })
+    vi.mocked(child_process.exec).mockImplementation(mockExec as any)
+
+    // Act
+    const result = await detectQCLI()
+
+    // Assert
+    expect(result).toBe('/custom/path/to/q')
+    expect(mockExec).toHaveBeenCalledWith('which /custom/path/to/q')
+  })
+
+  it('Q_BIN環境変数が未設定の場合、PATHからamazonqを検索する', async () => {
+    // Arrange
+    const mockExec = vi.fn().mockResolvedValue({ stdout: '/usr/local/bin/amazonq', stderr: '' })
+    vi.mocked(child_process.exec).mockImplementation(mockExec as any)
+
+    // Act
+    const result = await detectQCLI()
+
+    // Assert
+    expect(result).toBe('/usr/local/bin/amazonq')
+    expect(mockExec).toHaveBeenCalledWith('which amazonq')
+  })
+
+  it('amazonqが見つからない場合、qを検索する', async () => {
+    // Arrange
+    const mockExec = vi.fn()
+      .mockRejectedValueOnce(new Error('amazonq not found'))
+      .mockResolvedValueOnce({ stdout: '/usr/local/bin/q', stderr: '' })
+    vi.mocked(child_process.exec).mockImplementation(mockExec as any)
+
+    // Act
+    const result = await detectQCLI()
+
+    // Assert
+    expect(result).toBe('/usr/local/bin/q')
+    expect(mockExec).toHaveBeenCalledTimes(2)
+    expect(mockExec).toHaveBeenNthCalledWith(1, 'which amazonq')
+    expect(mockExec).toHaveBeenNthCalledWith(2, 'which q')
+  })
+
+  it('Q CLIが見つからない場合、エラーをスローする', async () => {
+    // Arrange
+    const mockExec = vi.fn()
+      .mockRejectedValueOnce(new Error('amazonq not found'))
+      .mockRejectedValueOnce(new Error('q not found'))
+    vi.mocked(child_process.exec).mockImplementation(mockExec as any)
+
+    // Act & Assert
+    await expect(detectQCLI()).rejects.toThrow(
+      'Amazon Q CLI が見つかりません。Q_BIN 環境変数を設定するか、amazonq をインストールしてください。'
+    )
+  })
+
+  it('Q_BIN環境変数の値が無効な場合、エラーをスローする', async () => {
+    // Arrange
+    process.env.Q_BIN = '/invalid/path/to/q'
+    const mockExec = vi.fn().mockRejectedValue(new Error('not found'))
+    vi.mocked(child_process.exec).mockImplementation(mockExec as any)
+
+    // Act & Assert
+    await expect(detectQCLI()).rejects.toThrow(
+      'Amazon Q CLI が見つかりません。Q_BIN 環境変数を設定するか、amazonq をインストールしてください。'
+    )
+  })
+})

--- a/src/lib/q-cli-detector.ts
+++ b/src/lib/q-cli-detector.ts
@@ -1,0 +1,43 @@
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execAsync = promisify(exec)
+
+/**
+ * Amazon Q CLIのバイナリパスを検出する
+ * 検出優先順位:
+ * 1. Q_BIN環境変数
+ * 2. PATHから'amazonq'
+ * 3. PATHから'q'
+ */
+export async function detectQCLI(): Promise<string> {
+  // Q_BIN環境変数が設定されている場合
+  if (process.env.Q_BIN) {
+    try {
+      const { stdout } = await execAsync(`which ${process.env.Q_BIN}`)
+      return stdout.trim()
+    } catch {
+      throw new Error(
+        'Amazon Q CLI が見つかりません。Q_BIN 環境変数を設定するか、amazonq をインストールしてください。'
+      )
+    }
+  }
+
+  // PATHから検索
+  const candidates = ['amazonq', 'q']
+  
+  for (const candidate of candidates) {
+    try {
+      const { stdout } = await execAsync(`which ${candidate}`)
+      return stdout.trim()
+    } catch {
+      // 次の候補を試す
+      continue
+    }
+  }
+
+  // すべての候補が見つからなかった場合
+  throw new Error(
+    'Amazon Q CLI が見つかりません。Q_BIN 環境変数を設定するか、amazonq をインストールしてください。'
+  )
+}

--- a/src/lib/spawn-q.test.ts
+++ b/src/lib/spawn-q.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { spawnQ, type SpawnQOptions } from './spawn-q.js'
+import { EventEmitter } from 'node:events'
+import { Readable } from 'node:stream'
+import child_process from 'node:child_process'
+
+vi.mock('./q-cli-detector.js', () => ({
+  detectQCLI: vi.fn().mockResolvedValue('/usr/local/bin/amazonq')
+}))
+
+vi.mock('node:child_process')
+
+describe('spawnQ関数', () => {
+  let mockChildProcess: any
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    
+    // child_processのモックを作成
+    mockChildProcess = new EventEmitter()
+    mockChildProcess.stdout = new Readable({
+      read() {}
+    })
+    mockChildProcess.stderr = new Readable({
+      read() {}
+    })
+    mockChildProcess.kill = vi.fn()
+    mockChildProcess.pid = 12345
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+  })
+
+  it('コマンドを実行し、標準出力を返す', async () => {
+    // Arrange
+    const mockSpawn = vi.fn().mockReturnValue(mockChildProcess)
+    vi.mocked(child_process.spawn).mockImplementation(mockSpawn)
+
+    const resultPromise = spawnQ(['--help'])
+
+    // 標準出力にデータを流す
+    mockChildProcess.stdout.push('Amazon Q CLI Help\n')
+    mockChildProcess.stdout.push('Version: 1.0.0\n')
+    mockChildProcess.stdout.push(null) // ストリーム終了
+
+    // プロセス正常終了
+    mockChildProcess.emit('close', 0)
+
+    // Act
+    const result = await resultPromise
+
+    // Assert
+    expect(result.stdout).toBe('Amazon Q CLI Help\nVersion: 1.0.0\n')
+    expect(result.stderr).toBe('')
+    expect(result.exitCode).toBe(0)
+    expect(mockSpawn).toHaveBeenCalledWith(
+      '/usr/local/bin/amazonq',
+      ['--help'],
+      expect.objectContaining({
+        stdio: ['inherit', 'pipe', 'pipe']
+      })
+    )
+  })
+
+  it('標準エラー出力も取得する', async () => {
+    // Arrange
+    const mockSpawn = vi.fn().mockReturnValue(mockChildProcess)
+    vi.mocked(child_process.spawn).mockImplementation(mockSpawn)
+
+    const resultPromise = spawnQ(['invalid-command'])
+
+    // 標準エラー出力にデータを流す
+    mockChildProcess.stderr.push('Error: Unknown command\n')
+    mockChildProcess.stderr.push(null)
+    mockChildProcess.stdout.push(null)
+
+    // プロセス異常終了
+    mockChildProcess.emit('close', 1)
+
+    // Act
+    const result = await resultPromise
+
+    // Assert
+    expect(result.stdout).toBe('')
+    expect(result.stderr).toBe('Error: Unknown command\n')
+    expect(result.exitCode).toBe(1)
+  })
+
+  it('タイムアウト時にエラーをスローする', async () => {
+    // Arrange
+    vi.useFakeTimers()
+    const mockSpawn = vi.fn().mockReturnValue(mockChildProcess)
+    vi.mocked(child_process.spawn).mockImplementation(mockSpawn)
+
+    const options: SpawnQOptions = { timeout: 1000 }
+    const resultPromise = spawnQ(['long-running-command'], options)
+
+    // タイムアウトを発生させる
+    vi.advanceTimersByTime(1000)
+
+    // Act & Assert
+    await expect(resultPromise).rejects.toThrow('コマンドがタイムアウトしました (1秒)')
+    expect(mockChildProcess.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('プロセス起動エラー時にエラーをスローする', async () => {
+    // Arrange
+    const mockSpawn = vi.fn().mockReturnValue(mockChildProcess)
+    vi.mocked(child_process.spawn).mockImplementation(mockSpawn)
+
+    const resultPromise = spawnQ(['test'])
+
+    // プロセスエラーを発生させる
+    mockChildProcess.emit('error', new Error('spawn error'))
+
+    // Act & Assert
+    await expect(resultPromise).rejects.toThrow('Q CLIの起動に失敗しました: spawn error')
+  })
+
+  it('onDataコールバックでストリーミングデータを受け取る', async () => {
+    // Arrange
+    const mockSpawn = vi.fn().mockReturnValue(mockChildProcess)
+    vi.mocked(child_process.spawn).mockImplementation(mockSpawn)
+
+    const stdoutChunks: string[] = []
+    const stderrChunks: string[] = []
+
+    const options: SpawnQOptions = {
+      onData: (type, data) => {
+        if (type === 'stdout') {
+          stdoutChunks.push(data)
+        } else {
+          stderrChunks.push(data)
+        }
+      }
+    }
+
+    const resultPromise = spawnQ(['stream-test'], options)
+
+    // ストリーミングデータを流す
+    mockChildProcess.stdout.push('chunk1')
+    mockChildProcess.stdout.push('chunk2')
+    mockChildProcess.stderr.push('error1')
+    mockChildProcess.stdout.push(null)
+    mockChildProcess.stderr.push(null)
+    mockChildProcess.emit('close', 0)
+
+    // Act
+    await resultPromise
+
+    // Assert
+    expect(stdoutChunks).toEqual(['chunk1', 'chunk2'])
+    expect(stderrChunks).toEqual(['error1'])
+  })
+
+  it('環境変数を渡すことができる', async () => {
+    // Arrange
+    const mockSpawn = vi.fn().mockReturnValue(mockChildProcess)
+    vi.mocked(child_process.spawn).mockImplementation(mockSpawn)
+
+    const options: SpawnQOptions = {
+      env: { CUSTOM_VAR: 'test-value' }
+    }
+
+    const resultPromise = spawnQ(['test'], options)
+
+    mockChildProcess.stdout.push(null)
+    mockChildProcess.stderr.push(null)
+    mockChildProcess.emit('close', 0)
+
+    // Act
+    await resultPromise
+
+    // Assert
+    expect(mockSpawn).toHaveBeenCalledWith(
+      '/usr/local/bin/amazonq',
+      ['test'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          CUSTOM_VAR: 'test-value'
+        })
+      })
+    )
+  })
+
+  it('作業ディレクトリを指定できる', async () => {
+    // Arrange
+    const mockSpawn = vi.fn().mockReturnValue(mockChildProcess)
+    vi.mocked(child_process.spawn).mockImplementation(mockSpawn)
+
+    const options: SpawnQOptions = {
+      cwd: '/custom/working/directory'
+    }
+
+    const resultPromise = spawnQ(['test'], options)
+
+    mockChildProcess.stdout.push(null)
+    mockChildProcess.stderr.push(null)
+    mockChildProcess.emit('close', 0)
+
+    // Act
+    await resultPromise
+
+    // Assert
+    expect(mockSpawn).toHaveBeenCalledWith(
+      '/usr/local/bin/amazonq',
+      ['test'],
+      expect.objectContaining({
+        cwd: '/custom/working/directory'
+      })
+    )
+  })
+})

--- a/src/lib/spawn-q.ts
+++ b/src/lib/spawn-q.ts
@@ -1,0 +1,100 @@
+import { spawn, type SpawnOptions } from 'node:child_process'
+import { detectQCLI } from './q-cli-detector.js'
+
+export interface SpawnQOptions {
+  /** タイムアウト（ミリ秒） */
+  timeout?: number
+  /** 環境変数 */
+  env?: Record<string, string>
+  /** 作業ディレクトリ */
+  cwd?: string
+  /** ストリーミングデータのコールバック */
+  onData?: (type: 'stdout' | 'stderr', data: string) => void
+}
+
+export interface SpawnQResult {
+  /** 標準出力 */
+  stdout: string
+  /** 標準エラー出力 */
+  stderr: string
+  /** 終了コード */
+  exitCode: number | null
+}
+
+/**
+ * Amazon Q CLIをspawnして実行する
+ * @param args コマンドライン引数
+ * @param options オプション
+ */
+export async function spawnQ(
+  args: string[],
+  options: SpawnQOptions = {}
+): Promise<SpawnQResult> {
+  const qBinaryPath = await detectQCLI()
+  
+  return new Promise((resolve, reject) => {
+    const spawnOptions: SpawnOptions = {
+      stdio: ['inherit', 'pipe', 'pipe'],
+      env: options.env ? { ...process.env, ...options.env } : process.env,
+      cwd: options.cwd
+    }
+
+    const child = spawn(qBinaryPath, args, spawnOptions)
+    
+    let stdout = ''
+    let stderr = ''
+    let timeoutId: NodeJS.Timeout | undefined
+    let isResolved = false
+
+    // タイムアウト設定
+    if (options.timeout) {
+      timeoutId = setTimeout(() => {
+        if (!isResolved) {
+          child.kill('SIGTERM')
+          isResolved = true
+          reject(new Error(`コマンドがタイムアウトしました (${options.timeout! / 1000}秒)`))
+        }
+      }, options.timeout)
+    }
+
+    // 標準出力の処理
+    if (child.stdout) {
+      child.stdout.on('data', (chunk) => {
+        const data = chunk.toString()
+        stdout += data
+        options.onData?.('stdout', data)
+      })
+    }
+
+    // 標準エラー出力の処理
+    if (child.stderr) {
+      child.stderr.on('data', (chunk) => {
+        const data = chunk.toString()
+        stderr += data
+        options.onData?.('stderr', data)
+      })
+    }
+
+    // プロセスエラーの処理
+    child.on('error', (error) => {
+      if (!isResolved) {
+        if (timeoutId) clearTimeout(timeoutId)
+        isResolved = true
+        reject(new Error(`Q CLIの起動に失敗しました: ${error.message}`))
+      }
+    })
+
+    // プロセス終了の処理
+    child.on('close', (code) => {
+      if (!isResolved) {
+        if (timeoutId) clearTimeout(timeoutId)
+        isResolved = true
+        resolve({
+          stdout,
+          stderr,
+          exitCode: code
+        })
+      }
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- Amazon Q CLIのバイナリ検出機能を実装
- 子プロセスとしてQ CLIを起動するspawnQ関数を実装
- エラーハンドリングとタイムアウト処理を含む

## 実装内容
### Q CLI検出機能 (`src/lib/q-cli-detector.ts`)
- `Q_BIN`環境変数をチェック
- PATHから`amazonq`または`q`を検索
- 見つからない場合は分かりやすいエラーメッセージを表示

### プロセス起動機能 (`src/lib/spawn-q.ts`)
- `child_process.spawn`を使用した非同期実行
- ストリーミング対応（stdout/stderr）
- タイムアウト処理
- 環境変数と作業ディレクトリのカスタマイズ

## Test plan
- [x] Q CLI検出のユニットテスト（モック使用）
- [x] spawnQ関数のユニットテスト（モック使用）
- [x] エラーハンドリングのテスト
- [x] 実際のQ CLIでの動作確認（`src/examples/test-spawn.ts`）

🤖 Generated with [Claude Code](https://claude.ai/code)