### PR TITLE
fix: diff表示の正規表現修正とヘッダー削除

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -51,6 +51,9 @@ export const App: React.FC<AppProps> = ({ version = '0.1.0' }) => {
 
   // セッションからの出力を処理
   useEffect(() => {
+    // バッファを保持するためのrefを使用
+    const bufferRef = { current: '' };
+    
     const handleData = (type: string, data: string) => {
       // ANSIエスケープシーケンスを完全に削除
       let cleanData = data;
@@ -74,7 +77,7 @@ export const App: React.FC<AppProps> = ({ version = '0.1.0' }) => {
         .replace(/^[\x1b\[]*\d+;\d+m/gm, '');     // 行頭のエスケープコード残骸のみ削除
       
       // バッファに追加
-      let buffer = streamBuffer + cleanData;
+      let buffer = bufferRef.current + cleanData;
       
       // 処理する行のリスト
       const linesToAdd: string[] = [];
@@ -106,7 +109,7 @@ export const App: React.FC<AppProps> = ({ version = '0.1.0' }) => {
             setCurrentProgressLine(progressLine);
           }
           
-          setStreamBuffer('');
+          bufferRef.current = '';
           return;
         } else {
           // 最後の部分だけを処理対象に
@@ -148,7 +151,7 @@ export const App: React.FC<AppProps> = ({ version = '0.1.0' }) => {
         }
         
         // バッファを更新
-        setStreamBuffer(incompleteBuffer);
+        bufferRef.current = incompleteBuffer;
       } else {
         // 改行がない場合、すべてをバッファに保持
         // ただし、文の終わりを検出したら出力する
@@ -175,12 +178,12 @@ export const App: React.FC<AppProps> = ({ version = '0.1.0' }) => {
               trimmedBuffer !== 'Thinking...' && 
               !trimmedBuffer.includes('Thinking...')) {
             linesToAdd.push(trimmedBuffer);
-            setStreamBuffer('');
+            bufferRef.current = '';
           } else {
-            setStreamBuffer(buffer);
+            bufferRef.current = buffer;
           }
         } else {
-          setStreamBuffer(buffer);
+          bufferRef.current = buffer;
         }
       }
       
@@ -215,7 +218,7 @@ export const App: React.FC<AppProps> = ({ version = '0.1.0' }) => {
       session.removeListener('exit', handleExit);
       session.removeListener('error', handleError);
     };
-  }, [session, streamBuffer]);
+  }, [session]);
   
   // キーバインドの処理
   useInput((input, key) => {

--- a/src/components/Output.test.tsx
+++ b/src/components/Output.test.tsx
@@ -221,4 +221,148 @@ describe('Output コンポーネント', () => {
       expect(output).not.toContain('[y/n/t]:');
     });
   });
+
+  describe('Markdown フォーマット', () => {
+    it('ヘッダーを適切にフォーマットする', () => {
+      const lines = [
+        '# H1 ヘッダー',
+        '## H2 ヘッダー',
+        '### H3 ヘッダー',
+        '#### H4 ヘッダー',
+        '##### H5 ヘッダー',
+        '###### H6 ヘッダー'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      expect(output).toContain('H1 ヘッダー');
+      expect(output).toContain('H2 ヘッダー');
+      expect(output).toContain('H3 ヘッダー');
+    });
+
+    it('太字テキストをフォーマットする', () => {
+      const lines = [
+        'これは **太字** のテストです',
+        'これは __太字__ のテストです'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      expect(output).toContain('太字');
+    });
+
+    it('イタリックテキストをフォーマットする', () => {
+      const lines = [
+        'これは *イタリック* のテストです',
+        'これは _イタリック_ のテストです'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      expect(output).toContain('イタリック');
+    });
+
+    it('インラインコードをフォーマットする', () => {
+      const lines = [
+        'これは `インラインコード` のテストです'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      expect(output).toContain('インラインコード');
+    });
+
+    it('コードブロックを美しくフォーマットする', () => {
+      const lines = [
+        '```typescript',
+        'const hello = "world";',
+        'console.log(hello);',
+        '```'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      expect(output).toContain('typescript');
+      expect(output).toContain('const hello');
+    });
+
+    it('リストを適切にフォーマットする', () => {
+      const lines = [
+        '- アイテム1',
+        '- アイテム2',
+        '  - サブアイテム',
+        '* アイテム3',
+        '+ アイテム4'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      expect(output).toContain('アイテム1');
+      expect(output).toContain('サブアイテム');
+    });
+
+    it('番号付きリストをフォーマットする', () => {
+      const lines = [
+        '1. 第一項目',
+        '2. 第二項目',
+        '   1. サブ項目',
+        '3. 第三項目'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      expect(output).toContain('第一項目');
+      expect(output).toContain('サブ項目');
+    });
+
+    it('引用をフォーマットする', () => {
+      const lines = [
+        '> これは引用です',
+        '> 複数行の引用',
+        '>> ネストした引用'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      expect(output).toContain('これは引用です');
+      expect(output).toContain('複数行の引用');
+    });
+
+    it('水平線を表示する', () => {
+      const lines = [
+        '---',
+        '***',
+        '___'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      // 水平線が何らかの形で表示されていることを確認
+      expect(output).toBeDefined();
+      expect(output?.length || 0).toBeGreaterThan(0);
+    });
+
+    it('リンクをフォーマットする', () => {
+      const lines = [
+        '[GitHub](https://github.com)',
+        '[ドキュメント](https://example.com/docs)'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      expect(output).toContain('GitHub');
+      expect(output).toContain('ドキュメント');
+    });
+  });
+
 });

--- a/src/components/Output.test.tsx
+++ b/src/components/Output.test.tsx
@@ -178,4 +178,47 @@ describe('Output コンポーネント', () => {
       expect(contentArea).not.toMatch(/^\s*[⋮]\s*$/m);
     });
   });
+
+  describe('Amazon Q CLI 確認メッセージ', () => {
+    it('ANSIエスケープシーケンスを含む確認メッセージを美しくフォーマットする', () => {
+      const lines = ['[?25h Allow this action? Use \'t\' to trust (always allow) this tool for the session. [y/n/t]:'];
+      const { lastFrame } = render(<Output lines={lines} />);
+      
+      const output = lastFrame();
+      expect(output).toContain('🔐 Amazon Q - Permission Required');
+      expect(output).toContain('Allow this action?');
+      expect(output).toContain('[y]');
+      expect(output).toContain('Yes - Allow once');
+      expect(output).toContain('[n]');
+      expect(output).toContain('No - Deny action');
+      expect(output).toContain('[t]');
+      expect(output).toContain('Trust - Always allow this tool');
+      expect(output).toContain('Enter your choice:');
+      // ANSIエスケープシーケンスは表示されない
+      expect(output).not.toContain('[?25h');
+    });
+
+    it('シンプルな確認メッセージもフォーマットする', () => {
+      const lines = ['Allow this action? [y/n/t]:'];
+      const { lastFrame } = render(<Output lines={lines} />);
+      
+      const output = lastFrame();
+      expect(output).toContain('🔐 Amazon Q - Permission Required');
+      expect(output).toContain('Allow this action?');
+      expect(output).toContain('[y]');
+      expect(output).toContain('[n]');
+      expect(output).toContain('[t]');
+    });
+
+    it('カスタムメッセージ付きの確認プロンプトもフォーマットする', () => {
+      const lines = ['[?25h Do you want to execute this command? Use \'t\' to trust this tool. [y/n/t]:'];
+      const { lastFrame } = render(<Output lines={lines} />);
+      
+      const output = lastFrame();
+      expect(output).toContain('🔐 Amazon Q - Permission Required');
+      expect(output).toContain('Do you want to execute this command?');
+      expect(output).not.toContain('[?25h');
+      expect(output).not.toContain('[y/n/t]:');
+    });
+  });
 });

--- a/src/components/Output.test.tsx
+++ b/src/components/Output.test.tsx
@@ -363,6 +363,28 @@ describe('Output コンポーネント', () => {
       expect(output).toContain('GitHub');
       expect(output).toContain('ドキュメント');
     });
+
+    it('背景色付きの要素を適切にレンダリングする', () => {
+      const lines = [
+        '# 重要な見出し',
+        '```javascript',
+        'console.log("test");',
+        '```',
+        '> 重要な引用',
+        '⚠️ 警告メッセージ',
+        '❌ エラーメッセージ'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      // 背景色付きで表示されることを確認
+      expect(output).toContain('重要な見出し');
+      expect(output).toContain('javascript');
+      expect(output).toContain('重要な引用');
+      expect(output).toContain('警告メッセージ');
+      expect(output).toContain('エラーメッセージ');
+    });
   });
 
 });

--- a/src/components/Output.test.tsx
+++ b/src/components/Output.test.tsx
@@ -48,4 +48,134 @@ describe('Output コンポーネント', () => {
     expect(output).toContain('Green text');
     expect(output).toContain('Red text');
   });
+
+  describe('Tool出力フォーマット', () => {
+    it('Tool使用開始を適切にフォーマットする', () => {
+      const lines = ['🛠️  Using tool: fs_read (trusted)'];
+      const { lastFrame } = render(<Output lines={lines} />);
+      
+      const output = lastFrame();
+      expect(output).toContain('🔧');
+      expect(output).toContain('fs_read');
+      expect(output).toContain('(trusted)');
+    });
+
+    it('Tool実行詳細を適切にフォーマットする', () => {
+      const lines = [
+        'Reading directory: /Users/test/project with maximum depth of 0',
+        'Writing file: /Users/test/project/output.txt',
+        'Processing data from input stream'
+      ];
+      const { lastFrame } = render(<Output lines={lines} />);
+      
+      const output = lastFrame();
+      expect(output).toContain('→');
+      expect(output).toContain('Reading directory');
+      expect(output).toContain('Writing file');
+      expect(output).toContain('Processing data');
+    });
+
+    it('Tool成功メッセージを適切にフォーマットする', () => {
+      const lines = [
+        '✓ Successfully read directory /Users/test/project (4 entries)',
+        '● ✓ Successfully created file output.txt'
+      ];
+      const { lastFrame } = render(<Output lines={lines} />);
+      
+      const output = lastFrame();
+      expect(output).toContain('✓');
+      expect(output).toContain('Successfully read directory');
+      expect(output).toContain('Successfully created file');
+    });
+
+    it('Tool完了メッセージを適切にフォーマットする', () => {
+      const lines = ['● Completed in 0.5s', '● Completed in 1.2s'];
+      const { lastFrame } = render(<Output lines={lines} />);
+      
+      const output = lastFrame();
+      expect(output).toContain('⏱');
+      expect(output).toContain('0.5s');
+      expect(output).toContain('1.2s');
+    });
+
+    it('Tool検証失敗を適切にフォーマットする', () => {
+      const lines = [
+        'Tool validation failed:',
+        'Failed to validate tool parameters: \'/Users/test/project/tasks\' is not a file'
+      ];
+      const { lastFrame } = render(<Output lines={lines} />);
+      
+      const output = lastFrame();
+      expect(output).toContain('⚠');
+      expect(output).toContain('Tool validation error');
+      expect(output).toContain('→');
+      expect(output).toContain('is not a file');
+    });
+
+    it('Tool関連の境界線マーカーを非表示にする', () => {
+      const lines = [
+        '│',
+        '⋮',
+        '●',
+        '│⋮●',
+        '  │⋮●  ',
+        'Valid content line'
+      ];
+      const { lastFrame } = render(<Output lines={lines} />);
+      
+      const output = lastFrame();
+      // ボーダー以外の境界線マーカーは表示されない（コンテンツエリアのみをチェック）
+      const contentArea = output?.split('\n').slice(1, -1).join('\n') || '';
+      expect(contentArea).not.toMatch(/^[│⋮●\s]*$/m);
+      // 有効なコンテンツは表示される
+      expect(output).toContain('Valid content line');
+    });
+
+    it('Tool関連の冗長な出力をフィルタする', () => {
+      const lines = [
+        '│⋮● some random output',
+        '● Reading file: important.txt', // これは表示される
+        '│⋮● another random line',
+        '✓ Successfully processed data' // これも表示される
+      ];
+      const { lastFrame } = render(<Output lines={lines} />);
+      
+      const output = lastFrame();
+      // 重要な情報のみ表示される
+      expect(output).toContain('Reading file');
+      expect(output).toContain('Successfully processed');
+      // 冗長な出力は表示されない
+      expect(output).not.toContain('some random output');
+      expect(output).not.toContain('another random line');
+    });
+
+    it('複数のTool出力を組み合わせて正しく表示する', () => {
+      const lines = [
+        '🛠️  Using tool: fs_read (trusted)',
+        '│',
+        '● Reading directory: /Users/test/project with maximum depth of 0',
+        '✓ Successfully read directory /Users/test/project (4 entries)',
+        '⋮',
+        '● Completed in 0.3s'
+      ];
+      const { lastFrame } = render(<Output lines={lines} />);
+      
+      const output = lastFrame();
+      // Tool名が表示される
+      expect(output).toContain('🔧');
+      expect(output).toContain('fs_read');
+      // 実行詳細が表示される
+      expect(output).toContain('→');
+      expect(output).toContain('Reading directory');
+      // 成功メッセージが表示される
+      expect(output).toContain('✓');
+      expect(output).toContain('Successfully read directory');
+      // 完了時間が表示される
+      expect(output).toContain('⏱');
+      expect(output).toContain('0.3s');
+      // 単独の境界線マーカー行は表示されない（コンテンツエリアをチェック）
+      const contentArea = output?.split('\n').slice(1, -1).join('\n') || '';
+      expect(contentArea).not.toMatch(/^\s*[⋮]\s*$/m);
+    });
+  });
 });

--- a/src/components/Output.test.tsx
+++ b/src/components/Output.test.tsx
@@ -385,6 +385,47 @@ describe('Output コンポーネント', () => {
       expect(output).toContain('警告メッセージ');
       expect(output).toContain('エラーメッセージ');
     });
+
+    it('コードブロック内のコンテンツに背景色を適用する', () => {
+      const lines = [
+        '```typescript',
+        'const hello = "world";',
+        'function greet(name: string) {',
+        '  return `Hello, ${name}!`;',
+        '}',
+        'console.log(greet("TypeScript"));',
+        '```'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      // コードブロック開始が表示される
+      expect(output).toContain('typescript');
+      // コード内容が表示される
+      expect(output).toContain('const hello');
+      expect(output).toContain('function greet');
+      expect(output).toContain('console.log');
+    });
+
+    it('プログラムコードっぽい行を自動検出して背景色を適用する', () => {
+      const lines = [
+        'import React from "react";',
+        'const Component = () => {',
+        '  const [state, setState] = useState(0);',
+        '  return <div>{state}</div>;',
+        '};',
+        'export default Component;'
+      ];
+      
+      const { lastFrame } = render(<Output lines={lines} />);
+      const output = lastFrame();
+      
+      // プログラムコードが表示される
+      expect(output).toContain('import React');
+      expect(output).toContain('const Component');
+      expect(output).toContain('useState');
+    });
   });
 
 });

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -9,6 +9,45 @@ interface OutputProps {
 
 // コードブロックやマークダウンの検出とスタイリング
 const formatLine = (line: string): React.ReactNode => {
+  // Amazon Q CLI ユーザー確認メッセージの処理
+  
+  // ANSIエスケープシーケンスを含む確認メッセージ
+  if (line.match(/\[?\?25h.*\[y\/n\/t\]:?|.*\[y\/n\/t\]:?\s*$/) && 
+      (line.includes('?25h') || line.match(/\b(Allow|trust|action|command|execute)\b/i))) {
+    // ANSIエスケープシーケンスを除去し、メッセージを抽出
+    const cleanLine = line
+      .replace(/\[?\?25h\s*/, '')
+      .replace(/\s*\[y\/n\/t\]:?\s*$/, '')
+      .replace(/Use\s+'[^']*'\s+to\s+trust[^.]*\./i, '')
+      .trim();
+    
+    return (
+      <Box flexDirection="column" marginY={1} paddingX={1} borderStyle="round" borderColor="yellow">
+        <Box>
+          <Text color="yellow" bold>🔐 Amazon Q - Permission Required</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text color="white">{cleanLine || 'Allow this action?'}</Text>
+        </Box>
+        <Box marginTop={1} flexDirection="row" gap={1}>
+          <Text color="green" bold>[y]</Text>
+          <Text color="gray">Yes - Allow once</Text>
+        </Box>
+        <Box flexDirection="row" gap={1}>
+          <Text color="red" bold>[n]</Text>
+          <Text color="gray">No - Deny action</Text>
+        </Box>
+        <Box flexDirection="row" gap={1}>
+          <Text color="cyan" bold>[t]</Text>
+          <Text color="gray">Trust - Always allow this tool</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text color="yellow" dimColor>Enter your choice: </Text>
+        </Box>
+      </Box>
+    );
+  }
+  
   // Amazon Q CLI Tools関連の出力を処理
   
   // Tool使用開始（🛠️  Using tool: xxx）

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -155,13 +155,19 @@ const formatLine = (line: string): React.ReactNode => {
     const level = headerMatch[1].length;
     const text = headerMatch[2];
     const colors = ['magenta', 'cyan', 'blue', 'green', 'yellow', 'white'];
+    const bgColors = ['magentaBright', 'cyanBright', 'blueBright', 'greenBright', 'yellowBright', 'blackBright'];
     const color = colors[level - 1] || 'white';
+    const backgroundColor = level <= 2 ? bgColors[level - 1] : undefined;
     const prefixes = ['◆', '◇', '◈', '◉', '○', '●'];
     const prefix = prefixes[level - 1] || '●';
     
     return (
-      <Box marginY={level <= 2 ? 1 : 0}>
-        <Text color={color} bold>
+      <Box marginY={level <= 2 ? 1 : 0} paddingX={backgroundColor ? 1 : 0}>
+        <Text 
+          color={backgroundColor ? 'black' : color} 
+          backgroundColor={backgroundColor}
+          bold
+        >
           {prefix} {text}
         </Text>
       </Box>
@@ -172,8 +178,8 @@ const formatLine = (line: string): React.ReactNode => {
   if (line.startsWith('```')) {
     const language = line.substring(3).trim();
     return (
-      <Box marginY={1}>
-        <Text color="yellow" dimColor>
+      <Box marginY={1} paddingX={1}>
+        <Text color="black" backgroundColor="yellowBright">
           {language ? `▼ ${language}` : '▼ Code'}
         </Text>
       </Box>
@@ -325,9 +331,10 @@ const formatLine = (line: string): React.ReactNode => {
   // エラーメッセージ
   if (line.startsWith('❌')) {
     return (
-      <Box>
-        <Text color="red">✗ </Text>
-        <Text color="red">{line.substring(1).trim()}</Text>
+      <Box paddingX={1}>
+        <Text color="white" backgroundColor="redBright">
+          ✗ {line.substring(2).trim()}
+        </Text>
       </Box>
     );
   }
@@ -355,9 +362,10 @@ const formatLine = (line: string): React.ReactNode => {
   // 警告メッセージ
   if (line.startsWith('⚠️')) {
     return (
-      <Box>
-        <Text color="yellow">⚠ </Text>
-        <Text color="yellow">{line.substring(2).trim()}</Text>
+      <Box paddingX={1}>
+        <Text color="black" backgroundColor="yellowBright">
+          ⚠ {line.substring(2).trim()}
+        </Text>
       </Box>
     );
   }

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -9,25 +9,44 @@ interface OutputProps {
 
 // コードブロックやマークダウンの検出とスタイリング
 const formatLine = (line: string): React.ReactNode => {
+  // 汎用的なANSIエスケープシーケンスの除去（最初に処理）
+  let cleanedLine = line;
+  
+  // 一般的なANSIエスケープシーケンスを除去
+  cleanedLine = cleanedLine
+    .replace(/\[?\?25h/g, '') // カーソル表示制御
+    .replace(/\[?\?25l/g, '') // カーソル非表示制御
+    .replace(/\x1b\[[0-9;]*[mKH]/g, '') // エスケープシーケンス（色・クリア等）
+    .replace(/\x1b\[[0-9;]*[mKH]/g, '') // エスケープシーケンス（16進表記）
+    .replace(/\[\?[0-9;]*[hlc]/g, '') // プライベートモードエスケープシーケンス
+    .trim();
+  
+  // 空行になった場合は処理しない
+  if (!cleanedLine) {
+    return null;
+  }
+  
+  // 以降の処理では cleanedLine を使用
+  line = cleanedLine;
+  
   // Amazon Q CLI ユーザー確認メッセージの処理
   
   // ANSIエスケープシーケンスを含む確認メッセージ
-  if (line.match(/\[?\?25h.*\[y\/n\/t\]:?|.*\[y\/n\/t\]:?\s*$/) && 
-      (line.includes('?25h') || line.match(/\b(Allow|trust|action|command|execute)\b/i))) {
-    // ANSIエスケープシーケンスを除去し、メッセージを抽出
-    const cleanLine = line
-      .replace(/\[?\?25h\s*/, '')
+  if (line.match(/.*\[y\/n\/t\]:?\s*$/) && 
+      line.match(/\b(Allow|trust|action|command|execute)\b/i)) {
+    // メッセージを抽出
+    const message = line
       .replace(/\s*\[y\/n\/t\]:?\s*$/, '')
       .replace(/Use\s+'[^']*'\s+to\s+trust[^.]*\./i, '')
       .trim();
-    
+
     return (
       <Box flexDirection="column" marginY={1} paddingX={1} borderStyle="round" borderColor="yellow">
         <Box>
           <Text color="yellow" bold>🔐 Amazon Q - Permission Required</Text>
         </Box>
         <Box marginTop={1}>
-          <Text color="white">{cleanLine || 'Allow this action?'}</Text>
+          <Text color="white">{message || 'Allow this action?'}</Text>
         </Box>
         <Box marginTop={1} flexDirection="row" gap={1}>
           <Text color="green" bold>[y]</Text>


### PR DESCRIPTION
## 概要
Amazon Q CLIのdiff表示機能の修正

## 変更内容

### 1. 正規表現のエスケープシーケンス修正
- 差分検出パターンで二重になっていたバックスラッシュを単一に修正
- `\\\\s*` → `\\s*` （空白文字）
- `\\\\d+` → `\\d+` （数字）
- `\\\\+` → `\\+` （プラス記号のエスケープ）

### 2. UI改善
- 「OLD (削除)」と「NEW (追加)」のヘッダー部分を削除
- よりシンプルで見やすい差分表示に改善

## 動作確認
- Amazon Q CLIの差分出力が正しく左右並列表示されることを確認
- 削除行（赤）と追加行（緑）が適切に色分けされることを確認
- 変更なし行がグレーで表示されることを確認

## 対象ファイル
- `src/components/Output.tsx`