### PR TITLE
feat(go/ui): 最小UIプロトタイプを追加（Header/Output/Input/Status）＋コメント日本語化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 coverage/
+go/.gocache/
 *.log
 .DS_Store
 .env

--- a/go/cmd/qube/main.go
+++ b/go/cmd/qube/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+    "log"
+
+    tea "github.com/charmbracelet/bubbletea"
+    "qube/internal/ui"
+)
+
+func main() {
+    m := ui.New()
+    if _, err := tea.NewProgram(&m).Run(); err != nil {
+        log.Fatal(err)
+    }
+}
+

--- a/go/internal/ui/model.go
+++ b/go/internal/ui/model.go
@@ -1,11 +1,15 @@
 package ui
 
 import (
-	tea "github.com/charmbracelet/bubbletea"
+    "fmt"
+    "strings"
+
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/charmbracelet/lipgloss"
 )
 
-// Mode represents the operational mode of the UI
-// command: execute short-lived commands, session: interactive
+// Mode は UI の動作モードを表す。
+// command: 短命コマンド実行, session: 対話セッション
 //go:generate stringer -type=Mode
 
 type Mode int
@@ -15,8 +19,8 @@ const (
 	ModeSession
 )
 
-// Status represents the current status shown in the status bar
-// ready: idle, running: processing, error: error occurred
+// Status はステータスバーに表示する状態を表す。
+// ready: アイドル, running: 実行中, error: エラー発生
 //go:generate stringer -type=Status
 
 type Status int
@@ -27,17 +31,17 @@ const (
 	StatusError
 )
 
-// MsgSubmit is emitted when user presses Enter to submit current input
-// and is handled by outer executor/session.
+// MsgSubmit は Enter で現在の入力を送信した際に発火する。
+// 実行（短命/セッション）は外側のコンポーネントが処理する。
 
 type MsgSubmit struct{ Value string }
 
-// History is a simple command history with pointer navigation
-// behavior mirrors src/lib/history.ts (dedup, pointer movement, cap omitted for MVP)
+// History はポインタ移動可能なシンプルなコマンド履歴。
+// 連続重複の除外やポインタ移動など、Node 版（src/lib/history.ts）に概ね合わせる。
 
 type History struct {
-	items   []string
-	pointer int // points to the index in items; len(items) means "blank"
+    items   []string
+    pointer int // items のインデックスを指す。len(items) は「空（ブランク）」を表す。
 }
 
 func NewHistory() History {
@@ -45,13 +49,13 @@ func NewHistory() History {
 }
 
 func (h *History) Add(text string) {
-	// deduplicate consecutive same entries
-	if len(h.items) > 0 && h.items[len(h.items)-1] == text {
-		return
-	}
-	h.items = append(h.items, text)
-	// after adding, reset pointer to blank (after last)
-	h.pointer = len(h.items)
+    // 直前と同じ入力は連続重複として追加しない
+    if len(h.items) > 0 && h.items[len(h.items)-1] == text {
+        return
+    }
+    h.items = append(h.items, text)
+    // 追加後はポインタを「空（最後の次）」へ移動
+    h.pointer = len(h.items)
 }
 
 func (h *History) Prev() (string, bool) {
@@ -67,7 +71,7 @@ func (h *History) Next() (string, bool) {
 	return h.items[h.pointer], true
 }
 
-// Model holds minimal UI state required for the prototype
+// Model は最小プロトタイプに必要な UI の状態を保持する。
 
 type Model struct {
 	mode           Mode
@@ -96,32 +100,117 @@ func New() Model {
 func (m Model) Init() tea.Cmd { return nil }
 
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch v := msg.(type) {
-	case tea.KeyMsg:
-		switch v.Type {
-		case tea.KeyCtrlC:
+    switch v := msg.(type) {
+    case tea.KeyMsg:
+        switch v.Type {
+        case tea.KeyCtrlC:
             return m, tea.Quit
-		case tea.KeyEnter:
-			text := m.input
-			if text == "" { return m, nil }
-			m.history.Add(text)
-			m.input = ""
-			return m, func() tea.Msg { return MsgSubmit{Value: text} }
-		case tea.KeyUp:
-			if s, ok := m.history.Prev(); ok { m.input = s }
-			return m, nil
-		case tea.KeyDown:
-			if s, ok := m.history.Next(); ok { m.input = s }
-			return m, nil
-		default:
-			// no-op for other keys in this minimal prototype
-			return m, nil
-		}
-	}
-	return m, nil
+        case tea.KeyEnter:
+            text := m.input
+            if text == "" { return m, nil }
+            m.history.Add(text)
+            m.input = ""
+            return m, func() tea.Msg { return MsgSubmit{Value: text} }
+        case tea.KeyBackspace, tea.KeyCtrlH:
+            // バックスペースで末尾 1 文字（rune）を削除
+            if m.input != "" {
+                r := []rune(m.input)
+                if len(r) > 0 { m.input = string(r[:len(r)-1]) }
+            }
+            return m, nil
+        case tea.KeyRunes:
+            // 入力された文字（rune）を末尾に追加
+            if len(v.Runes) > 0 {
+                m.input += string(v.Runes)
+            }
+            return m, nil
+        case tea.KeyUp:
+            if s, ok := m.history.Prev(); ok { m.input = s }
+            return m, nil
+        case tea.KeyDown:
+            if s, ok := m.history.Next(); ok { m.input = s }
+            return m, nil
+        default:
+            // 最小プロトタイプのためそれ以外は無視
+            return m, nil
+        }
+    }
+    return m, nil
 }
 
 func (m Model) View() string {
-	// Minimal placeholder; actual lipgloss rendering will come later
-	return ""
+    // スタイル定義
+    headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12"))
+    boxStyle := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
+    faint := lipgloss.NewStyle().Faint(true)
+
+    // ヘッダー
+    header := headerStyle.Render(fmt.Sprintf("Qube • %s • %s", m.modeString(), m.statusString()))
+
+    // 出力（履歴 + 進捗行）
+    bodyLines := make([]string, 0, len(m.lines)+1)
+    bodyLines = append(bodyLines, m.lines...)
+    if m.progressLine != nil {
+        bodyLines = append(bodyLines, faint.Render(*m.progressLine))
+    }
+    body := boxStyle.Render(strings.Join(bodyLines, "\n"))
+
+    // 入力
+    prompt := "▶ "
+    input := boxStyle.Render(prompt + m.input)
+
+    // ステータスバー
+    help := "^C Exit  ↑↓ History  Enter Send"
+    statusBar := faint.Render(fmt.Sprintf("Mode:%s  Status:%s  Errors:%d  %s", m.modeStringShort(), m.statusStringShort(), m.errorCount, help))
+
+    return strings.Join([]string{header, body, input, statusBar}, "\n")
+}
+
+// 描画用の表記変換ヘルパ
+func (m Model) modeString() string {
+    switch m.mode {
+    case ModeCommand:
+        return "Command"
+    case ModeSession:
+        return "Session"
+    default:
+        return "?"
+    }
+}
+
+func (m Model) modeStringShort() string {
+    switch m.mode {
+    case ModeCommand:
+        return "Cmd"
+    case ModeSession:
+        return "Chat"
+    default:
+        return "?"
+    }
+}
+
+func (m Model) statusString() string {
+    switch m.status {
+    case StatusReady:
+        return "Ready"
+    case StatusRunning:
+        return "Running"
+    case StatusError:
+        return "Error"
+    default:
+        return "?"
+    }
+}
+
+func (m Model) statusStringShort() string {
+    switch m.status {
+    case StatusReady:
+        return "ready"
+    case StatusRunning:
+        return "running"
+    case StatusError:
+        return "error"
+    default:
+        return "?"
+    }
 }

--- a/go/internal/ui/model.go
+++ b/go/internal/ui/model.go
@@ -1,0 +1,127 @@
+package ui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Mode represents the operational mode of the UI
+// command: execute short-lived commands, session: interactive
+//go:generate stringer -type=Mode
+
+type Mode int
+
+const (
+	ModeCommand Mode = iota
+	ModeSession
+)
+
+// Status represents the current status shown in the status bar
+// ready: idle, running: processing, error: error occurred
+//go:generate stringer -type=Status
+
+type Status int
+
+const (
+	StatusReady Status = iota
+	StatusRunning
+	StatusError
+)
+
+// MsgSubmit is emitted when user presses Enter to submit current input
+// and is handled by outer executor/session.
+
+type MsgSubmit struct{ Value string }
+
+// History is a simple command history with pointer navigation
+// behavior mirrors src/lib/history.ts (dedup, pointer movement, cap omitted for MVP)
+
+type History struct {
+	items   []string
+	pointer int // points to the index in items; len(items) means "blank"
+}
+
+func NewHistory() History {
+	return History{items: make([]string, 0), pointer: 0}
+}
+
+func (h *History) Add(text string) {
+	// deduplicate consecutive same entries
+	if len(h.items) > 0 && h.items[len(h.items)-1] == text {
+		return
+	}
+	h.items = append(h.items, text)
+	// after adding, reset pointer to blank (after last)
+	h.pointer = len(h.items)
+}
+
+func (h *History) Prev() (string, bool) {
+	if len(h.items) == 0 { return "", false }
+	if h.pointer > 0 { h.pointer-- }
+	return h.items[h.pointer], true
+}
+
+func (h *History) Next() (string, bool) {
+	if len(h.items) == 0 { return "", false }
+	if h.pointer < len(h.items) { h.pointer++ }
+	if h.pointer == len(h.items) { return "", true }
+	return h.items[h.pointer], true
+}
+
+// Model holds minimal UI state required for the prototype
+
+type Model struct {
+	mode           Mode
+	status         Status
+	input          string
+	history        History
+	lines          []string
+	progressLine   *string
+	errorCount     int
+	currentCommand string
+}
+
+func New() Model {
+	return Model{
+		mode:         ModeCommand,
+		status:       StatusReady,
+		input:        "",
+		history:      NewHistory(),
+		lines:        []string{},
+		progressLine: nil,
+		errorCount:   0,
+		currentCommand: "",
+	}
+}
+
+func (m Model) Init() tea.Cmd { return nil }
+
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch v := msg.(type) {
+	case tea.KeyMsg:
+		switch v.Type {
+		case tea.KeyCtrlC:
+            return m, tea.Quit
+		case tea.KeyEnter:
+			text := m.input
+			if text == "" { return m, nil }
+			m.history.Add(text)
+			m.input = ""
+			return m, func() tea.Msg { return MsgSubmit{Value: text} }
+		case tea.KeyUp:
+			if s, ok := m.history.Prev(); ok { m.input = s }
+			return m, nil
+		case tea.KeyDown:
+			if s, ok := m.history.Next(); ok { m.input = s }
+			return m, nil
+		default:
+			// no-op for other keys in this minimal prototype
+			return m, nil
+		}
+	}
+	return m, nil
+}
+
+func (m Model) View() string {
+	// Minimal placeholder; actual lipgloss rendering will come later
+	return ""
+}

--- a/go/internal/ui/model_test.go
+++ b/go/internal/ui/model_test.go
@@ -1,0 +1,100 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func Test_NewModel_DefaultState(t *testing.T) {
+	m := New()
+	if m.mode != ModeCommand {
+		t.Fatalf("mode: got %v, want %v", m.mode, ModeCommand)
+	}
+	if m.status != StatusReady {
+		t.Fatalf("status: got %v, want %v", m.status, StatusReady)
+	}
+	if m.input != "" {
+		t.Fatalf("input: got %q, want empty", m.input)
+	}
+	if len(m.history.items) != 0 {
+		t.Fatalf("history length: got %d, want 0", len(m.history.items))
+	}
+	if m.progressLine != nil {
+		t.Fatalf("progressLine: got non-nil, want nil")
+	}
+	if len(m.lines) != 0 {
+		t.Fatalf("lines length: got %d, want 0", len(m.lines))
+	}
+	if m.errorCount != 0 {
+		t.Fatalf("errorCount: got %d, want 0", m.errorCount)
+	}
+	if m.currentCommand != "" {
+		t.Fatalf("currentCommand: got %q, want empty", m.currentCommand)
+	}
+}
+
+func Test_Update_EnterSubmitsMsgAndClearsInputAndAddsHistory(t *testing.T) {
+	m := New()
+	m.input = "echo hi"
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatalf("cmd is nil; want MsgSubmit")
+	}
+	msg := cmd()
+	switch v := msg.(type) {
+	case MsgSubmit:
+		if v.Value != "echo hi" {
+			t.Fatalf("MsgSubmit value: got %q, want %q", v.Value, "echo hi")
+		}
+	default:
+		t.Fatalf("unexpected msg type: %T", msg)
+	}
+	if m.input != "" {
+		t.Fatalf("input not cleared: got %q, want empty", m.input)
+	}
+	if len(m.history.items) != 1 || m.history.items[0] != "echo hi" {
+		t.Fatalf("history not updated: %#v", m.history.items)
+	}
+}
+
+func Test_Update_UpDownHistoryNavigation(t *testing.T) {
+	m := New()
+	m.history.Add("one")
+	m.history.Add("two")
+
+	// Up -> two
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.input != "two" {
+		t.Fatalf("after 1x Up: got %q, want %q", m.input, "two")
+	}
+	// Up -> one
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.input != "one" {
+		t.Fatalf("after 2x Up: got %q, want %q", m.input, "one")
+	}
+	// Down -> two
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if m.input != "two" {
+		t.Fatalf("after Down: got %q, want %q", m.input, "two")
+	}
+	// Down -> ""
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if m.input != "" {
+		t.Fatalf("after 2x Down: got %q, want empty", m.input)
+	}
+}
+
+func Test_Update_CtrlCQuits(t *testing.T) {
+	m := New()
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd == nil {
+		t.Fatalf("cmd is nil; want tea.Quit")
+	}
+	msg := cmd()
+	if reflect.TypeOf(msg) != reflect.TypeOf(tea.QuitMsg{}) {
+		t.Fatalf("got %T, want tea.QuitMsg", msg)
+	}
+}

--- a/go/internal/ui/model_test.go
+++ b/go/internal/ui/model_test.go
@@ -65,22 +65,22 @@ func Test_Update_UpDownHistoryNavigation(t *testing.T) {
 	m.history.Add("one")
 	m.history.Add("two")
 
-	// Up -> two
+    // 上矢印: two へ
 	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
 	if m.input != "two" {
 		t.Fatalf("after 1x Up: got %q, want %q", m.input, "two")
 	}
-	// Up -> one
+    // 上矢印: one へ
 	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
 	if m.input != "one" {
 		t.Fatalf("after 2x Up: got %q, want %q", m.input, "one")
 	}
-	// Down -> two
+    // 下矢印: two へ
 	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
 	if m.input != "two" {
 		t.Fatalf("after Down: got %q, want %q", m.input, "two")
 	}
-	// Down -> ""
+    // 下矢印: 空文字 へ
 	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
 	if m.input != "" {
 		t.Fatalf("after 2x Down: got %q, want empty", m.input)

--- a/plan/migrate-to-bubble-tea.md
+++ b/plan/migrate-to-bubble-tea.md
@@ -52,10 +52,10 @@
 - ディレクティブ: 行頭 `>>SET_LAST_CMD: <text>` はエコーバック抑制用に `lastSentCommand` を設定
 
 ## 4. 最小 UI プロトタイプ（Go）
-- [ ] `tea.Model` で `state {mode,status,input,history,lines,progressLine,errorCount,currentCommand}` を定義
+- [x] `tea.Model` で `state {mode,status,input,history,lines,progressLine,errorCount,currentCommand}` を定義
 - [ ] Header/StatusBar/Output/Input の最小実装（色/枠は lipgloss で近似）
-- [ ] Enter で `MsgSubmit(value)`、↑↓ で履歴移動（`CommandHistory` 相当を Go 実装）
-- [ ] Ctrl+C ハンドリング（`tea.Quit`）
+- [x] Enter で `MsgSubmit(value)`、↑↓ で履歴移動（`CommandHistory` 相当を Go 実装）
+- [x] Ctrl+C ハンドリング（`tea.Quit`）
 
 ## 5. ストリーム処理の移植
 - [ ] `StreamProcessor` のロジックを Go 実装に移植

--- a/plan/migrate-to-bubble-tea.md
+++ b/plan/migrate-to-bubble-tea.md
@@ -53,7 +53,7 @@
 
 ## 4. 最小 UI プロトタイプ（Go）
 - [x] `tea.Model` で `state {mode,status,input,history,lines,progressLine,errorCount,currentCommand}` を定義
-- [ ] Header/StatusBar/Output/Input の最小実装（色/枠は lipgloss で近似）
+- [x] Header/StatusBar/Output/Input の最小実装（色/枠は lipgloss で近似）
 - [x] Enter で `MsgSubmit(value)`、↑↓ で履歴移動（`CommandHistory` 相当を Go 実装）
 - [x] Ctrl+C ハンドリング（`tea.Quit`）
 


### PR DESCRIPTION
【概要】
- Bubble Tea最小UI（Header/Output/Input/Status）を追加
- 入力編集（文字入力・バックスペース）
- セクション4のチェック完了（plan/migrate-to-bubble-tea.md）
- コメントを日本語（常体）に統一
- gitignore に `go/.gocache/` を追加（差分ノイズ防止）

【実行】
- `go run ./go/cmd/qube`

【テスト】
- Node: `npx vitest run --pool=threads --maxWorkers=1` で全緑（98 tests）
- Go: `cd go && GOCACHE=$(pwd)/.gocache go test ./...` で OK

【補足】
- 表示ラベル（Mode/Status）の文言は現状英語。必要なら日本語化可。
- Node版CLIへの影響なし。

[EN] Add minimal Bubble Tea UI prototype (Header/Output/Input/Status), unify comments in Japanese, and ignore go/.gocache.
